### PR TITLE
Fix: Replace jquery's sunsetted find()

### DIFF
--- a/src/main/resources/utils.js
+++ b/src/main/resources/utils.js
@@ -261,7 +261,7 @@ define('plugin/prnfb/utils', [
 
  $(document).ready(function() {
   listFieldChanged($(this));
-  $('.listfield').find('input, textarea').live('keyup', function() {
+  $(document).on('keyup', '.listfield input, .listfield textarea', function() {
    listFieldChanged($(this));
   });
  });


### PR DESCRIPTION
Reason:
`.find()` was deprecated by jQuery through v2.2.4.11 and had been removed completely now in favor of `.on()`